### PR TITLE
GitHub CI & editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# Editor config ripped from dlang repository : https://github.com/dlang/dlang.org/blob/master/.editorconfig
+root = true
+
+[*.{c,h,d,di,dd,ddoc}]
+end_of_line = lf
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+charset = utf-8
+

--- a/.github/workflows/d.yml
+++ b/.github/workflows/d.yml
@@ -1,0 +1,47 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+name: D
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+        dc:
+          - dmd-latest
+          - dmd-2.086.1
+          - ldc-latest
+        exclude:
+          - { os: macOS-latest, dc: dmd-2.086.1 }
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Setup D compiler
+        uses: dlang-community/setup-dlang@v1
+        with:
+          compiler: ${{ matrix.dc }}
+
+      - name: Checkout source
+        uses: actions/checkout@v2
+
+      - name: 'Build'
+        run: |
+          # Release build
+          dub build --parallel -b release
+          dub clean --all-packages -q
+          # Run tests
+      - name: 'Tests'
+        run: dub test --parallel
+


### PR DESCRIPTION
Configures github actions to compile & execute unittests with different compilers (dmd & ldc) & OS.
Also, adds a .editorconfig to enforce some minimal formatting convention.