### PR TITLE
Fix a string comparing bug & remove ldc flag

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -21,8 +21,7 @@
         },
         {
             "name": "unittest",
-            "targetType": "library",
-            "dflags-ldc": ["-fsanitize=address"]
+            "targetType": "library"
         }
     ]
 }

--- a/tests/betterc-test.d
+++ b/tests/betterc-test.d
@@ -1,7 +1,6 @@
 module betterc_test;
 
 import bcaa;
-import bcaa: Mallocator;
 
 import core.stdc.stdio;
 import core.stdc.time;


### PR DESCRIPTION
fixed the bug:
```d
Bcaa!(string, string) aa;
scope(exit) aa.free;
aa["foo".idup] = "bar";
assert(aa.foo == "bar");
```